### PR TITLE
Apeboard api-secret header workaround

### DIFF
--- a/yield.rb/apeboard.rb
+++ b/yield.rb/apeboard.rb
@@ -74,7 +74,12 @@ class ApeBoard
       {
         "#{prefix} #{name}" => JSON.parse(
           Utils.http_get(
-            [API_URI, url_prefix, name, wallet].reject(&:empty?).join("/")
+            [API_URI, url_prefix, name, wallet].reject(&:empty?).join("/"),
+            {
+              "origin" => "apeboard.finance",
+              "ape-secret" => "U2FsdGVkX1+cTatAJ47gsc43jtt8TKOCcHtjQ0jLCkIxOe/0zas5drvoaftIOQ7u2YCJ+A3qe3/OE0NuNMCqVXGoigeV8Ddbuwsqp/1F4NdUE3evdLplm5GWHMpOLfbOfw+d1si/XfHRl/31sgJEPg==",
+              "passcode" => "5a102a34f60fa8ec9d643e8a0e72cab9"
+            }
           )
         )
       }

--- a/yield.rb/utils.rb
+++ b/yield.rb/utils.rb
@@ -2,11 +2,15 @@ require 'bigdecimal'
 
 module Utils
   class << self
-    def http_get(uri)
+    def http_get(uri, headers={})
       uri = URI(uri)
       res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
         req = Net::HTTP::Get.new(uri)
         req["Content-Type"] = "application/json"
+
+        headers.each do |key, value|
+          req[key] = value
+        end
 
         http.request(req)
       end


### PR DESCRIPTION
Since a few days ago, Apeboard sends some keys in its headers